### PR TITLE
Take path to bib-journal-abbreviation into account when reading journ…

### DIFF
--- a/journal_abbrev.py
+++ b/journal_abbrev.py
@@ -2,6 +2,7 @@ import sys
 import json
 import re
 import argparse
+import os
 
 def abbreviate(line, journal_to_abbr):
     if re.search('".*"', line) is not None:
@@ -37,7 +38,10 @@ if __name__ == '__main__':
     parser.add_argument('--user-json', type=str, default=None, help="customized json file")
     args = parser.parse_args()
 
-    with open('journals.json') as fin:
+    basepath = os.path.dirname(os.path.abspath(__file__))
+    jsonfile = os.path.join(basepath, 'journals.json')
+
+    with open(jsonfile) as fin:
         journal_to_abbr = json.load(fin)
 
     if args.user_json is not None:


### PR DESCRIPTION
…als.json

One might want to run journal_abbrev.py from another directory. For example:

`cat unabbrev.bib | python ~/src/bib-journal-abbreviation/journal-abbrev.py > abbrev.bib`

This doesn't work in the current master branch. Problem is, journal_abbrev.py assumes journals.json is available in the current directory. This pull request implements reading the path of journal-abbrev.py and adds that in front of journals.json before reading the latter. Consequently, the example above works just fine in this branch.